### PR TITLE
Add GH Action for testing translations, fix builds for fr translation

### DIFF
--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -1,0 +1,35 @@
+name: Test Translations
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install build dependencies
+      run: sudo apt install ubuntu-dev-tools default-jre docbook-xml docbook-xsl fonts-dejavu-core fonts-noto fop itstool libxml2-utils xsltproc
+    - name: make clean
+      run: make clean
+    - name: make user-get-translations
+      run: make user-get-translations
+    - name: make contributor-get-translations TRANSPERC=20
+      run: make contributor-get-translations TRANSPERC=20
+    - name: make user-html
+      run: make user-html
+    - name: make user-html-translations
+      run: make user-html-translations
+    - name: make contributor-html
+      run: make contributor-html
+    - name: make contributor-html-translations TRANSPERC=20
+      run: make contributor-html-translations TRANSPERC=20
+    - name: make startpage
+      run: make startpage REVNO=${GITHUB_SHA}
+    - name: make test 
+      run: make test 

--- a/contributor-docs/po/LINGUAS
+++ b/contributor-docs/po/LINGUAS
@@ -1,6 +1,2 @@
-de
 en_GB
-es
-fr
 id
-pt_BR

--- a/contributor-docs/po/LINGUAS
+++ b/contributor-docs/po/LINGUAS
@@ -1,1 +1,6 @@
+de
 en_GB
+es
+fr
+id
+pt_BR

--- a/user-docs/po/LINGUAS
+++ b/user-docs/po/LINGUAS
@@ -1,6 +1,8 @@
 de
+en_GB
 es
 fi
+fr
 pt
 pt_BR
 ru

--- a/user-docs/po/fr.po
+++ b/user-docs/po/fr.po
@@ -1738,8 +1738,7 @@ msgid ""
 msgstr ""
 "Le gestionnaire de mises à jour vous informera lorsqu'une nouvelle version "
 "est disponible au téléchargement pour votre mode de mise à niveau. Pour "
-"changer votre mode de mise à niveau, voir <xref linkend=\"Changer votre mode "
-"de mise à niveau\"/>."
+"changer votre mode de mise à niveau, voir <xref linkend=\"changing-upgrade-path\"/>."
 
 #: user-docs/C/migrating-upgrading.xml:60(para)
 msgid ""
@@ -2658,8 +2657,7 @@ msgstr ""
 "d'un meilleur accès, pour télécharger les paquets et chercher d'éventuelles "
 "mises à jour, notamment de sécurité. Il vous faudra seulement du temps, de "
 "la patience et un périphérique de stockage USB. Un exemple pour en savoir "
-"plus à ce sujet est présenté dans <xref linkend=\"Gestion des paquets hors-"
-"ligne\"/>."
+"plus à ce sujet est présenté dans <xref linkend=\"offline-packages\"/>."
 
 #: user-docs/C/managing-applications.xml:128(title)
 msgid "Changing update frequency and behavior"


### PR DESCRIPTION
This PR creates a new GitHub action for testing translations at 20% completion and fixes build issues with the fr translation where link references were accidentally translated.